### PR TITLE
Update labels in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: "🐛 Bug Report"
 description: "If something isn't working as expected with Deno Deploy 🤔."
 title: "[Bug]: "
-labels: ["i: needs triage"]
+labels: []
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: "🚀 Feature Request"
 description: "I have a specific suggestion for Deno Deploy!"
-labels: ["i: needs triage", "i: enhancement"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/kv.yml
+++ b/.github/ISSUE_TEMPLATE/kv.yml
@@ -1,7 +1,7 @@
 name: "📝 Deno KV Feedback"
 description: "Share your feedback, bug reports, or feature requests for Deno KV."
 title: "[Feedback]: "
-labels: ["i: needs triage", "i: kv"]
+labels: ["kv"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/kv.yml
+++ b/.github/ISSUE_TEMPLATE/kv.yml
@@ -1,6 +1,6 @@
 name: "📝 Deno KV Feedback"
 description: "Share your feedback, bug reports, or feature requests for Deno KV."
-title: "[Feedback]: "
+title: "[KV Feedback]: "
 labels: ["kv"]
 body:
   - type: markdown


### PR DESCRIPTION
I sent a "Hey look, Deno copied our templates!" message to the rest of the Babel team, and I noticed that you copied _too much_ 😛 The `i: needs triage` and `i: enhancement` labels are specific for the Babel repo.

This PR
- removes the `i: needs triage` label, since I didn't find anything similar in the Deno repos
- renames `i: enhancement` to just `enhancement`, since it's a label that you use
- renames `i: kv` to just `kv` (since you don't use the `i: ` prefix for any other label). It's not a label that exists yet in this repo, but since it was explicitly written by @ry it's probably something you want. You should however manually [create that label](hhttps://github.com/denoland/deploy_feedback/labels), otherwise the issue template won't automatically apply it.

I noticed that you use a `bug` label, but I didn't add it to the bug issue template because in the Babel repo we noticed that the invalid-bug-report to issue-opened-as-bug ratio is quite high (many of them are just questions or user errors): automatically adding the label is mostly noise.